### PR TITLE
Add CRUD for topics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'rails_12factor', '~> 0.0.3', group: :production
 gem 'rack-cors', '~> 0.4.0', require: 'rack/cors'
 gem 'simple_token_authentication', '~> 1.6.0'
 
+# Use to soft delete records
+gem 'paranoia', '~> 2.1.5'
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,8 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
+    paranoia (2.1.5)
+      activerecord (~> 4.0)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     pg (0.18.2)
@@ -331,6 +333,7 @@ DEPENDENCIES
   jbuilder (~> 1.2)
   koala (~> 1.10.0rc)
   letter_opener (~> 1.4.1)
+  paranoia (~> 2.1.5)
   pg (~> 0.18.2)
   pry-byebug (~> 3.3.0)
   pry-rails (~> 0.3.4)
@@ -353,4 +356,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/app/admin/topic.rb
+++ b/app/admin/topic.rb
@@ -1,0 +1,29 @@
+ActiveAdmin.register Topic do
+  permit_params :name
+
+  form do |f|
+    f.inputs 'New Topic' do
+      input :name
+    end
+
+    f.actions
+  end
+
+  index do
+    selectable_column
+    id_column
+    column :name
+
+    actions
+  end
+
+  filter :id
+  filter :name
+
+  show do
+    attributes_table do
+      row :id
+      row :name
+    end
+  end
+end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,26 +1,15 @@
 ActiveAdmin.register User do
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
   permit_params :email, :first_name, :last_name, :username
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:permitted, :attributes]
-  #   permitted << :other if resource.something?
-  #   permitted
-  # end
 
-  form do
-    inputs 'Details' do
+  form do |f|
+    f.inputs 'Details' do
       input :email
       input :first_name
       input :last_name
       input :username
     end
 
-    actions
+    f.actions
   end
 
   index do

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: topics
+#
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  deleted_at :datetime
+#
+# Indexes
+#
+#  index_topics_on_deleted_at  (deleted_at)
+#  index_topics_on_name        (name) UNIQUE
+#
+
+class Topic < ActiveRecord::Base
+  acts_as_paranoid
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20160805171111_create_topics.rb
+++ b/db/migrate/20160805171111_create_topics.rb
@@ -1,0 +1,11 @@
+class CreateTopics < ActiveRecord::Migration
+  def change
+    create_table :topics do |t|
+      t.string :name, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :topics, :name, unique: true
+  end
+end

--- a/db/migrate/20160808145952_add_deleted_at_to_topics.rb
+++ b/db/migrate/20160808145952_add_deleted_at_to_topics.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToTopics < ActiveRecord::Migration
+  def change
+    add_column :topics, :deleted_at, :datetime
+    add_index :topics, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160801194707) do
+ActiveRecord::Schema.define(version: 20160808145952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,16 @@ ActiveRecord::Schema.define(version: 20160801194707) do
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+
+  create_table "topics", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
+  end
+
+  add_index "topics", ["deleted_at"], name: "index_topics_on_deleted_at", using: :btree
+  add_index "topics", ["name"], name: "index_topics_on_name", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: ""

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: topics
+#
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  deleted_at :datetime
+#
+# Indexes
+#
+#  index_topics_on_deleted_at  (deleted_at)
+#  index_topics_on_name        (name) UNIQUE
+#
+
+FactoryGirl.define do
+  factory :topic do
+    name { Faker::Name.first_name }
+  end
+end


### PR DESCRIPTION
## Add CRUD for topics in admin views
#### Description:
- Added topics' CRUD for admins to be able to create them

---
#### Tasks:
- [x] Add the topic model with its migrations, add the active admin topic.rb file and modify the user.rb active admin file

---
#### Risk:
- Low

---
#### Preview:
- N/A
